### PR TITLE
Implement basic Laravel-like router

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -1,0 +1,10 @@
+<?php
+$router->get('/', function() {
+    header('Location: ' . SITE_URL . '/tr');
+});
+
+$router->get('/tr', 'Index@index');
+$router->get('/tr/contact', 'Index@contact');
+$router->post('/tr/news/save', 'Index@savenews');
+$router->post('/tr/news/update', 'Index@updatenews');
+$router->post('/tr/news/delete', 'Index@deletenews');

--- a/index.php
+++ b/index.php
@@ -32,16 +32,18 @@ define('BASEPATH', 'MINIMVC');
  * 
  * @param type $className
  */
-function __autoload($className){
+spl_autoload_register(function ($className) {
     include_once "system/libs/" . $className . ".php";
-}
+});
 
 /**
  * Include your configration file.
  */
 include_once "app/config/config.php";
 
-$parser = new URLParser();
+$router = new Router();
+include_once "app/routes.php";
+$router->dispatch();
 
 ob_flush();
 ?>

--- a/system/libs/Router.php
+++ b/system/libs/Router.php
@@ -1,0 +1,77 @@
+<?php
+class Router {
+    protected $routes = [];
+
+    public function get($uri, $action) {
+        $this->add('GET', $uri, $action);
+    }
+
+    public function post($uri, $action) {
+        $this->add('POST', $uri, $action);
+    }
+
+    protected function add($method, $uri, $action) {
+        $uri = '/' . trim($uri, '/');
+        $this->routes[$method][$uri] = $action;
+    }
+
+    public function dispatch() {
+        $method = $_SERVER['REQUEST_METHOD'];
+        $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+        $base = str_replace('index.php', '', $_SERVER['SCRIPT_NAME']);
+        if (strpos($uri, $base) === 0) {
+            $uri = substr($uri, strlen($base));
+        }
+        $uri = '/' . trim($uri, '/');
+        $params = [];
+        $action = null;
+        if ($this->match($method, $uri, $params, $action)) {
+            $this->callAction($action, $params);
+            return;
+        }
+        // fallback to legacy parser
+        new URLParser();
+    }
+
+    protected function match($method, $uri, &$params, &$action) {
+        if (!isset($this->routes[$method])) {
+            return false;
+        }
+        foreach ($this->routes[$method] as $route => $act) {
+            $pattern = preg_replace('#\{[^/]+\}#', '([^/]+)', $route);
+            $pattern = '#^' . $pattern . '$#';
+            if (preg_match($pattern, $uri, $matches)) {
+                array_shift($matches);
+                $params = $matches;
+                $action = $act;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function callAction($action, $params) {
+        if (is_callable($action)) {
+            call_user_func_array($action, $params);
+            return;
+        }
+        if (is_string($action)) {
+            $parts = explode('@', $action);
+            $controller = ucwords($parts[0]);
+            $method = $parts[1] ?? 'index';
+            $file = 'app/controllers/' . $controller . '.php';
+            if (file_exists($file)) {
+                include_once $file;
+                if (class_exists($controller)) {
+                    $obj = new $controller();
+                    if (method_exists($obj, $method)) {
+                        call_user_func_array([$obj, $method], $params);
+                        return;
+                    }
+                }
+            }
+        }
+        header('HTTP/1.1 404 Not Found');
+        echo 'Route not found';
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a `Router` class that handles GET/POST route definitions and dispatches requests
- register autoloader with `spl_autoload_register`
- add new `routes.php` file containing route definitions
- update `index.php` to use the router instead of the old `URLParser`

## Testing
- `php -l system/libs/Router.php`
- `php -l index.php`
- `php -l app/routes.php`
- `php -l system/libs/Controller.php`

------
https://chatgpt.com/codex/tasks/task_e_688bbf597930832d90ba13cbd1752717